### PR TITLE
feat(theme): Add Dark Mode Toggle

### DIFF
--- a/assets/css/theme.css
+++ b/assets/css/theme.css
@@ -1,0 +1,9 @@
+:root{
+  --bg:#ffffff; --text:#0b0f13; --link:#0067b8; --muted:#f5f7fb; --border:#e2e8f0;
+}
+[data-theme="dark"]{
+  --bg:#0b0f13; --text:#e6eaf2; --link:#61a6ff; --muted:#111827; --border:#334155;
+}
+html,body{background:var(--bg);color:var(--text);}
+a{color:var(--link);}
+pre,code{background:var(--muted);border:1px solid var(--border);}

--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -1,0 +1,15 @@
+(() => {
+  const KEY = 'theme';
+  const media = window.matchMedia('(prefers-color-scheme: dark)');
+  const set = t => { document.documentElement.setAttribute('data-theme', t); localStorage.setItem(KEY, t); };
+
+  const saved = localStorage.getItem(KEY);
+  set(saved || (media.matches ? 'dark' : 'light'));
+  if (media.addEventListener) media.addEventListener('change', e => { if (!localStorage.getItem(KEY)) set(e.matches ? 'dark' : 'light'); });
+
+  document.addEventListener('click', e => {
+    const btn = e.target.closest('#theme-toggle');
+    if (!btn) return;
+    set(document.documentElement.getAttribute('data-theme') === 'dark' ? 'light' : 'dark');
+  });
+})();

--- a/index.md
+++ b/index.md
@@ -4,6 +4,10 @@ permalink: index.html
 layout: home
 ---
 
+<button id="theme-toggle" aria-label="Toggle dark mode">🌓</button>
+<link rel="stylesheet" href="{{ '/assets/css/theme.css' | relative_url }}">
+<script src="{{ '/assets/js/theme.js' | relative_url }}"></script>
+
 The following exercises are designed to provide you with a hands-on learning experience in which you'll explore common tasks that developers do when building generative AI solutions on Microsoft Azure.
 
 > **Note**: To complete the exercises, you'll need an Azure subscription in which you have sufficient permissions and quota to provision the necessary Azure resources and generative AI models. If you don't already have one, you can sign up for an [Azure account](https://azure.microsoft.com/free). There's a free trial option for new users that includes credits for the first 30 days.


### PR DESCRIPTION


**Description:**
Adds a dark mode to the site using CSS variables and a simple JavaScript toggle.

**Changes proposed in this pull request:**

* Added `/assets/css/theme.css` with light and dark theme variables.
* Added `/assets/js/theme.js` to handle theme switching and preference saving.
* Inserted a 🌓 toggle button at the top of the page.
* Respects OS-level `prefers-color-scheme` when no saved preference.

**Module:** 00
**Lab/Demo:** 00

**Fixes:** #114


