### PR TITLE
Fix Python virtual environment activation instructions for Step 8

### DIFF
--- a/Instructions/02a-AI-foundry-sdk.md
+++ b/Instructions/02a-AI-foundry-sdk.md
@@ -90,8 +90,21 @@ Now that you have deployed a model, you can use the Foundry and Azure OpenAI SDK
 1. In the cloud shell command-line pane, enter the following command to install the libraries you'll use:
 
     ```
+   # Create a Python virtual environment
    python -m venv labenv
-   ./labenv/bin/Activate.ps1
+   
+   # Activate the virtual environment
+
+   # On Bash (Linux, macOS, or Cloud Shell)
+   source labenv/bin/activate
+
+   # On Windows PowerShell
+   .\labenv\Scripts\Activate.ps1
+
+   # On Windows Command Prompt
+   Scripts\activate.bat
+
+   # Install required packages
    pip install -r requirements.txt azure-identity azure-ai-projects openai
     ```
 1. Enter the following command to edit the configuration file that has been provided:


### PR DESCRIPTION
The current Step 8 instructions use a Unix-style virtual environment path:

    ./labenv/bin/Activate.ps1

This path does not work on Windows.  

Updated Step 8 to include platform-specific activation commands:

- Bash (Linux/macOS/Cloud Shell): source labenv/bin/activate
- Windows PowerShell: .\labenv\Scripts\Activate.ps1
- Windows Command Prompt: Scripts\activate.bat
